### PR TITLE
Library doesent work with current React Native version.

### DIFF
--- a/android/src/main/java/com/cunyutech/hollyliu/reactnative/wallpaper/WallPaperPackage.java
+++ b/android/src/main/java/com/cunyutech/hollyliu/reactnative/wallpaper/WallPaperPackage.java
@@ -13,11 +13,6 @@ import java.util.List;
 public class WallPaperPackage implements ReactPackage {
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }


### PR DESCRIPTION
reateJSModules need to be removed to work correctly with React Native versions over 0.47.
Current wallpaper-manager version is not compiling because of that override.